### PR TITLE
Hard pin at the minor version for express dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ repos/
 *.old
 .DS_Store
 tmp/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     , "socket.io":  "0.8.x"
     , "uglify-js":  "1.2.x"
     , "validator":  "0.3.x"
-    , "express":    ">=2.5.x"
+    , "express":    "~=2.5.x"
   }
 
   , "engines": { "node": ">= 0.6.0" }


### PR DESCRIPTION
There have been API incompatible changes in the multiple major releases that have been released since 2.5.x
